### PR TITLE
Adding pixelHeight option and bumping version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage
 3. Load the Scroll Table Body plugin
 4. Make sure you have a table with proper markup (`<thead>`, `<tbody>`, and `<tfoot>` if you want it)
 5. Call `.scrollTableBody()` on your table element, which by default displays 10 rows of your table and scrolls the rest
-6. Optional: pass `rowsToDisplay` as an option.  For example, `$('table').scrollTableBody({rowsToDisplay:5});`
+6. Optional: pass `rowsToDisplay` or `pixelHeight` as an option.  For example, `$('table').scrollTableBody({rowsToDisplay: 5});` or `$('table').scrollTableBody({pixelHeight: 200});`
 
 Example
 -------

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "jquery.scrollTableBody",
+  "version": "1.0.1",
+  "homepage": "https://github.com/mikeokner/jquery.scrollTableBody",
+  "authors": [
+    "Michael Okner <mike@mikeokner.com>",
+    "Noah Heldman <noah.heldman@gmail.com>"
+  ],
+  "description": "Easily scroll HTML table bodies while header/footer remain fixed",
+  "main": "src/jquery.scrollTableBody-1.0.1.js",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "scroll",
+    "table",
+    "body",
+    "jquery",
+    "overflow"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/demo/fixed.html
+++ b/demo/fixed.html
@@ -11,7 +11,7 @@
     
         <script src="../lib/jquery-1.10.2.min.js"></script>
         <script src="../lib/underscore-1.5.2.min.js"></script>
-        <script src="../src/jquery.scrollTableBody-1.0.0.js"></script>
+        <script src="../src/jquery.scrollTableBody-1.0.1.js"></script>
     </head>
     
     <body>
@@ -27,7 +27,7 @@
             <li>Load the Scroll Table Body plugin</li>
             <li>Make sure you have a table with proper markup (<code>&lt;thead&gt;</code>, <code>&lt;tbody&gt;</code>, and <code>&lt;tfoot&gt;</code> if you want it)
             <li>Call <code>.scrollTableBody()</code> on your table element, which by default displays 10 rows of your table and scrolls the rest</li>
-            <li>Optional: pass <code>rowsToDisplay</code> as an option.  For example, <code>$('table').scrollTableBody({rowsToDisplay:5});</code></li>
+            <li>Optional: pass <code>rowsToDisplay</code> or <code>pixelHeight</code> as an option.  For example, <code>$('table').scrollTableBody({rowsToDisplay:5});</code> or <code>$('table').scrollTableBody({pixelHeight: 200});</code></li>
         </ol>
         
         <h2>Fixed Width Demo</h2>

--- a/demo/horizontal.html
+++ b/demo/horizontal.html
@@ -12,7 +12,7 @@
     
         <script src="../lib/jquery-1.10.2.min.js"></script>
         <script src="../lib/underscore-1.5.2.min.js"></script>
-        <script src="../src/jquery.scrollTableBody-1.0.0.js"></script>
+        <script src="../src/jquery.scrollTableBody-1.0.1.js"></script>
     </head>
     
     <body>
@@ -28,7 +28,7 @@
             <li>Load the Scroll Table Body plugin</li>
             <li>Make sure you have a table with proper markup (<code>&lt;thead&gt;</code>, <code>&lt;tbody&gt;</code>, and <code>&lt;tfoot&gt;</code> if you want it)
             <li>Call <code>.scrollTableBody()</code> on your table element, which by default displays 10 rows of your table and scrolls the rest</li>
-            <li>Optional: pass <code>rowsToDisplay</code> as an option.  For example, <code>$('table').scrollTableBody({rowsToDisplay:5});</code></li>
+            <li>Optional: pass <code>rowsToDisplay</code> or <code>pixelHeight</code> as an option.  For example, <code>$('table').scrollTableBody({rowsToDisplay:5});</code> or <code>$('table').scrollTableBody({pixelHeight: 200});</code></li>
         </ol>
         
         <h2>Horizontal Scroll Demo</h2>

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
     
         <script src="../lib/jquery-1.10.2.min.js"></script>
         <script src="../lib/underscore-1.5.2.min.js"></script>
-        <script src="../src/jquery.scrollTableBody-1.0.0.js"></script>
+        <script src="../src/jquery.scrollTableBody-1.0.1.js"></script>
     </head>
     
     <body>
@@ -26,7 +26,7 @@
             <li>Load the Scroll Table Body plugin</li>
             <li>Make sure you have a table with proper markup (<code>&lt;thead&gt;</code>, <code>&lt;tbody&gt;</code>, and <code>&lt;tfoot&gt;</code> if you want it)
             <li>Call <code>.scrollTableBody()</code> on your table element, which by default displays 10 rows of your table and scrolls the rest</li>
-            <li>Optional: pass <code>rowsToDisplay</code> as an option.  For example, <code>$('table').scrollTableBody({rowsToDisplay:5});</code></li>
+            <li>Optional: pass <code>rowsToDisplay</code> or <code>pixelHeight</code> as an option.  For example, <code>$('table').scrollTableBody({rowsToDisplay:5});</code> or <code>$('table').scrollTableBody({pixelHeight: 200});</code></li>
         </ol>
         
         <h2>Basic Demo</h2>

--- a/src/jquery.scrollTableBody-1.0.1.js
+++ b/src/jquery.scrollTableBody-1.0.1.js
@@ -24,7 +24,13 @@
         var existingMarginBottom = table.css('margin-bottom');
         table.css('margin-bottom', 0);
         var rowHeight = table.find('tbody tr:first').outerHeight();
-        var tableHeight = rowHeight * options.rowsToDisplay;
+        var tableHeight;
+        if (typeof options.pixelHeight !== 'undefined') {
+            tableHeight = options.pixelHeight;
+        }
+        else {
+            tableHeight = rowHeight * options.rowsToDisplay;
+        }
         
         var headerTable = $('<table style="table-layout:fixed;width:auto;margin-bottom:0;" class="jqstb-header-table ' + existingClasses + '"><thead><tr><td></td></tr></thead></table>'),
             footerTable = $('<table style="table-layout:fixed;width:auto;margin-bottom:' + existingMarginBottom + ';" class="jqstb-footer-table ' + existingClasses + '"><tfoot><tr><td></td></tr></tfoot></table>'),


### PR DESCRIPTION
Allow users to specify a `pixelHeight` for the scrolling table body. Can be useful for scaling to parent container's size without calculating `$(element).height() / row_size`.
