### PR TITLE
Fix initial row-height calculation to accomodate for variable height rows

### DIFF
--- a/src/jquery.scrollTableBody-1.0.0.js
+++ b/src/jquery.scrollTableBody-1.0.0.js
@@ -23,8 +23,10 @@
         var existingClasses = table.attr('class');
         var existingMarginBottom = table.css('margin-bottom');
         table.css('margin-bottom', 0);
-        var rowHeight = table.find('tbody tr:first').outerHeight();
-        var tableHeight = rowHeight * options.rowsToDisplay;
+        var tableHeight = 0;
+        $.each(rows, function () {
+            tableHeight += $(this).outerHeight();
+        });
         
         var headerTable = $('<table style="table-layout:fixed;width:auto;margin-bottom:0;" class="jqstb-header-table ' + existingClasses + '"><thead><tr><td></td></tr></thead></table>'),
             footerTable = $('<table style="table-layout:fixed;width:auto;margin-bottom:' + existingMarginBottom + ';" class="jqstb-footer-table ' + existingClasses + '"><tfoot><tr><td></td></tr></tfoot></table>'),

--- a/src/jquery.scrollTableBody-1.0.0.js
+++ b/src/jquery.scrollTableBody-1.0.0.js
@@ -23,7 +23,9 @@
         var existingClasses = table.attr('class');
         var existingMarginBottom = table.css('margin-bottom');
         table.css('margin-bottom', 0);
+
         var tableHeight = 0;
+        var rows = table.find('tbody tr:lt(' + options.rowsToDisplay.toString() + ')');
         $.each(rows, function () {
             tableHeight += $(this).outerHeight();
         });


### PR DESCRIPTION
The change I did makes sure that the initial view of the table shows the correct height to the number of rows defined by rowsToDisplay property